### PR TITLE
Fix test http://www.perl.org 

### DIFF
--- a/lib/AnyEvent/Curl/Multi.pm
+++ b/lib/AnyEvent/Curl/Multi.pm
@@ -10,7 +10,7 @@ use WWW::Curl::Multi;
 use Scalar::Util qw(refaddr);
 use HTTP::Response;
 
-our $VERSION = '1.1';
+our $VERSION = '1.1001';
 
 # Test whether subsecond timeouts are supported.
 eval { CURLOPT_TIMEOUT_MS(); }; my $MS_TIMEOUT_SUPPORTED = $@ ? 0 : 1;

--- a/t/cb.t
+++ b/t/cb.t
@@ -23,7 +23,7 @@ subtest good => sub {
         my ($response, $stats) = $handle->cv->recv;
         isa_ok($response, 'HTTP::Response');
         isa_ok($stats, 'HASH');
-        ok($response->is_success, "HTTP response from $GOOD_TEST_URL was successful");
+        like($response->code, qr/30\d/, "HTTP response from $GOOD_TEST_URL was successful");
     };
     is ($@, '', "callback didn't die");
 };

--- a/t/simple.t
+++ b/t/simple.t
@@ -24,6 +24,6 @@ my (undef, undef, $response, $stats) = $cv->recv;
 isa_ok($response, 'HTTP::Response');
 isa_ok($stats, 'HASH');
 
-ok($response->is_success, "HTTP response from $TEST_URL was successful");
+like($response->code, qr/30\d/, "HTTP response from $TEST_URL was successful") or diag("Code: ".$response->code);
 
 # vim:syn=perl:ts=4:sw=4:et:ai


### PR DESCRIPTION
Fixing  tests cause of http://www.perl.org redirects to https:// instead of expected 200 code.